### PR TITLE
Fixing compile error on Ubuntu system

### DIFF
--- a/Search.cpp
+++ b/Search.cpp
@@ -136,7 +136,7 @@ void Trans::Hashentry::store(locktype lock, score sc, int work) {
     return found ? it->second : nada;
   }
   void Book::bopen() {
-    bd = open(bookfile, O_CREAT|O_WRONLY|O_APPEND);
+    bd = open(bookfile, O_CREAT|O_WRONLY|O_APPEND, S_IRUSR|S_IWUSR);
     assert(bd >= 0);
   }
   void Book::bclose() {


### PR DESCRIPTION
Compile error on Ubuntu system at Search.cpp:139:50:
call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT in second argument needs 3 arguments
